### PR TITLE
CHQ-16 Adding docker bits for mongodb development

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -310,3 +310,6 @@ selenium-debug.log
 
 # NPM things
 package-lock.json
+
+# Project specific things
+data/

--- a/app/api/api.csproj
+++ b/app/api/api.csproj
@@ -8,6 +8,9 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.All" Version="2.0.5"/>
     <PackageReference Include="Newtonsoft.Json" Version="11.0.1"/>
+    <PackageReference Include="MongoDB.Driver" Version="2.5.0"/>
+    <PackageReference Include="MongoDB.Driver.Core" Version="2.5.0"/>
+    <PackageReference Include="MongoDB.Bson" Version="2.5.0"/>
   </ItemGroup>
   <ItemGroup>
     <DotNetCliToolReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Tools" Version="2.0.2"/>

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,13 @@
+version: '2'
+services:
+    mongodb:
+        container_name: "mongodb"
+        image: mongo:latest
+        environment:
+            - MONGO_DATA_DIR=/data/db
+            - MONGO_LOG_DIR=/dev/null
+        volumes:
+            - ./data/db:/data/db
+        ports:
+            - 27017:27017
+        command: mongod --smallfiles --logpath=/dev/null  # --quiet

--- a/docs/local_dev.md
+++ b/docs/local_dev.md
@@ -28,7 +28,11 @@
   * `cd <root>/app/api`
   * `dotnet restore`
 
-## Running the applications
+## Running the applications and dependencies
+* Dependencies
+  * Note: Most, if not all, of the non-external dependences should be controllable through the standard `docker-compose` services. The `up` and `down` commands are usually sufficient but feel free to see `docker-compose` for help.
+  * MongoDB
+    * `docker-compose up -d mongodb`
 * UI Project
   * `cd <root>/app/ui`
   * `npm run dev`


### PR DESCRIPTION
### Story
https://maddonkeysoftware.myjetbrains.com/youtrack/issue/CHQ-16

### Summary
* Added `docker-compose.yml` to the project
* Added MongoDB dependences to the API project
* Added documentation for local development setup on running docker dependencies.
* Added exclude to .gitignore for mongo's data directory.
  * This was done so that developers can kill the docker container and not loose any local development data.

### Testing
* Start / stop docker container for mongo db.