### PR TITLE
CHQ-58 Split Job and JobSpec. Now job messages are stored in Mongo.

### DIFF
--- a/app/api/Controllers/V1/JobController.cs
+++ b/app/api/Controllers/V1/JobController.cs
@@ -55,7 +55,7 @@ namespace Api.Controllers.V1
         {
             this.logger.LogDebug(1001, "Adding new job to the queue.");
             var newJobUuid = Guid.NewGuid();
-            var col = this.dbFactory.GetCollection<Job<object>>("corp-hq", CollectionNames.Jobs);
+            var col = this.dbFactory.GetCollection<JobSpec<object>>("corp-hq", CollectionNames.Jobs);
 
             var messages = VerifyJobType(jobDetails.JobType);
             if (messages.Count() > 0)
@@ -63,13 +63,15 @@ namespace Api.Controllers.V1
                 return this.BadRequest(new { messages = messages });
             }
 
-            col.InsertOne(new Job<object>
+            // TODO: Make Job expirary configurable via the settings db.
+            col.InsertOne(new JobSpec<object>
             {
                 Uuid = newJobUuid.ToString(),
                 Type = jobDetails.JobType,
 
                 // Data = JsonConvert.SerializeObject(new Dictionary<string, string> { { "arg", "arg1" } })
-                Data = null
+                Data = null,
+                ExpireAt = DateTime.Now.AddDays(3)
             });
 
             using (var connection = this.connectionFactory.CreateConnection())

--- a/app/api/Model/EnqueueJob.cs
+++ b/app/api/Model/EnqueueJob.cs
@@ -1,0 +1,20 @@
+// Copyright (c) MadDonkeySoftware
+
+namespace Api.Model
+{
+    using System.ComponentModel.DataAnnotations;
+    using Newtonsoft.Json;
+
+    /// <summary>
+    /// A class that represents the data submitted for user registration.
+    /// </summary>
+    public class EnqueueJob
+    {
+        /// <summary>
+        /// Gets or sets the job type.
+        /// </summary>
+        [Required]
+        [JsonProperty("jobType")]
+        public string JobType { get; set; }
+    }
+}

--- a/app/common/Data/CollectionNames.cs
+++ b/app/common/Data/CollectionNames.cs
@@ -7,9 +7,10 @@ namespace Common.Data
     /// </summary>
     public struct CollectionNames
     {
-        public static readonly string Jobs = "jobs";
-        public static readonly string Runners = "runners";
-        public static readonly string Settings = "settings";
-        public static readonly string Users = "users";
+        public const string Jobs = "jobs";
+        public const string Regions = "regions";
+        public const string Runners = "runners";
+        public const string Settings = "settings";
+        public const string Users = "users";
     }
 }

--- a/app/common/Data/CollectionNames.cs
+++ b/app/common/Data/CollectionNames.cs
@@ -7,6 +7,7 @@ namespace Common.Data
     /// </summary>
     public struct CollectionNames
     {
+        public const string JobMessages = "jobMessages";
         public const string Jobs = "jobs";
         public const string Regions = "regions";
         public const string Runners = "runners";

--- a/app/common/JobTypes.cs
+++ b/app/common/JobTypes.cs
@@ -8,5 +8,6 @@ namespace Common
     public struct JobTypes
     {
         public const string ApplyDbIndexes = "ApplyDbIndexes";
+        public const string ImportMapData = "ImportMapData";
     }
 }

--- a/app/common/Model/Eve/Region.cs
+++ b/app/common/Model/Eve/Region.cs
@@ -1,0 +1,33 @@
+// Copyright (c) MadDonkeySoftware
+
+namespace Common.Model.Eve
+{
+    using System.Collections.Generic;
+    using Common.Model;
+    using MongoDB.Bson;
+    using MongoDB.Bson.Serialization.Attributes;
+
+    /// <summary>
+    /// A sample class
+    /// </summary>
+    public class Region : MongoBase
+    {
+        /// <summary>
+        /// Gets or sets the region id.
+        /// </summary>
+        [BsonElement("regionId")]
+        public int RegionId { get; set; }
+
+        /// <summary>
+        /// Gets or sets the name.
+        /// </summary>
+        [BsonElement("name")]
+        public string Name { get; set; }
+
+        /// <summary>
+        /// Gets or sets the associated constellations.
+        /// </summary>
+        [BsonElement("constellationIds")]
+        public List<int> ConstellationIds { get; set; }
+    }
+}

--- a/app/common/Model/JobMessage.cs
+++ b/app/common/Model/JobMessage.cs
@@ -1,0 +1,33 @@
+// Copyright (c) MadDonkeySoftware
+
+namespace Common.Model
+{
+    using System;
+    using Common.Model;
+    using MongoDB.Bson;
+    using MongoDB.Bson.Serialization.Attributes;
+
+    /// <summary>
+    /// A class representing a user inside of the system.
+    /// </summary>
+    public class JobMessage : MongoBase
+    {
+        /// <summary>
+        /// Gets or sets the job uuid.
+        /// </summary>
+        [BsonElement("jobUuid")]
+        public string JobUuid { get; set; }
+
+        /// <summary>
+        /// Gets or sets the type of job.
+        /// </summary>
+        [BsonElement("timestamp")]
+        public DateTime Timestamp { get; set; }
+
+        /// <summary>
+        /// Gets or sets the message.
+        /// </summary>
+        [BsonElement("message")]
+        public string Message { get; set; }
+    }
+}

--- a/app/common/Model/JobSpec.cs
+++ b/app/common/Model/JobSpec.cs
@@ -1,0 +1,20 @@
+// Copyright (c) MadDonkeySoftware
+
+namespace Common.Model
+{
+    using Common.Model;
+    using MongoDB.Bson;
+    using MongoDB.Bson.Serialization.Attributes;
+
+    /// <summary>
+    /// A class representing a user inside of the system.
+    /// </summary>
+    public class JobSpec<T> : JobSpecLite where T : class
+    {
+        /// <summary>
+        /// Gets or sets the data for the job.
+        /// </summary>
+        [BsonElement("arguments")]
+        public T Data { get; set; }
+    }
+}

--- a/app/common/Model/JobSpecLite.cs
+++ b/app/common/Model/JobSpecLite.cs
@@ -9,7 +9,7 @@ namespace Common.Model
     /// <summary>
     /// A class representing a user inside of the system.
     /// </summary>
-    public class Job<T> : MongoBase where T : class
+    public class JobSpecLite : MongoBase
     {
         /// <summary>
         /// Gets or sets the uuid.
@@ -22,11 +22,5 @@ namespace Common.Model
         /// </summary>
         [BsonElement("type")]
         public string Type { get; set; }
-
-        /// <summary>
-        /// Gets or sets the data for the job.
-        /// </summary>
-        [BsonElement("arguments")]
-        public T Data { get; set; }
     }
 }

--- a/app/common/Model/MongoBase.cs
+++ b/app/common/Model/MongoBase.cs
@@ -2,6 +2,7 @@
 
 namespace Common.Model
 {
+    using System;
     using MongoDB.Bson;
     using MongoDB.Bson.Serialization.Attributes;
     using Newtonsoft.Json;
@@ -21,5 +22,11 @@ namespace Common.Model
         [JsonIgnore]
         [BsonId]
         public ObjectId BaseId { get; set; }
+
+        /// <summary>
+        /// Gets or sets the name.
+        /// </summary>
+        [BsonElement("expireAt")]
+        public DateTime? ExpireAt { get; set; }
     }
 }

--- a/app/runner/JobFactory.cs
+++ b/app/runner/JobFactory.cs
@@ -37,6 +37,9 @@ namespace Runner
                 case JobTypes.ApplyDbIndexes:
                     job = new CreateMongoIndexes();
                     break;
+                case JobTypes.ImportMapData:
+                    job = new ImportMapData();
+                    break;
                 default:
                     job = null;
                     break;

--- a/app/runner/JobFactory.cs
+++ b/app/runner/JobFactory.cs
@@ -26,28 +26,22 @@ namespace Runner
         /// <summary>
         /// Creates a new IJob instance for the appropriate job type.
         /// </summary>
-        /// <param name="key">The job type to initialize the job for.</param>
-        /// <param name="data">And data needing to be supplied to the job.</param>
+        /// <param name="jobSpec">The job specification to initialize the job for.</param>
         /// <returns>An instance of a job ready to be started.</returns>
-        public static IJob AcquireJob(string key, dynamic data)
+        public static IJob AcquireJob(JobSpecLite jobSpec)
         {
-            IJob<dynamic> job;
-            switch (key)
+            IJob job;
+            switch (jobSpec.Type)
             {
                 case JobTypes.ApplyDbIndexes:
-                    job = new CreateMongoIndexes();
+                    job = new CreateMongoIndexes(jobSpec.Uuid);
                     break;
                 case JobTypes.ImportMapData:
-                    job = new ImportMapData();
+                    job = new ImportMapData(jobSpec.Uuid);
                     break;
                 default:
                     job = null;
                     break;
-            }
-
-            if (job != null)
-            {
-                job.Data = data;
             }
 
             return (IJob)job;

--- a/app/runner/Jobs/CreateMongoIndexes.cs
+++ b/app/runner/Jobs/CreateMongoIndexes.cs
@@ -23,12 +23,12 @@ namespace Runner.Jobs
 
         private void CreateRunnersIndexes(IDbFactory dbFactory)
         {
-            Console.WriteLine("Starting to apply indexes");
+            this.AddMessage("Starting to apply indexes");
             var runnerCol = dbFactory.GetCollection<dynamic>("corp-hq", CollectionNames.Runners);
             runnerCol.Indexes.CreateOne(
                 Builders<dynamic>.IndexKeys.Ascending("expireAt"),
                 new CreateIndexOptions { ExpireAfter = TimeSpan.FromSeconds(0) });
-            Console.WriteLine("Finished applying indexes");
+            this.AddMessage("Finished applying indexes");
         }
     }
 }

--- a/app/runner/Jobs/CreateMongoIndexes.cs
+++ b/app/runner/Jobs/CreateMongoIndexes.cs
@@ -10,25 +10,48 @@ namespace Runner.Jobs
     /// <summary>
     /// Job for creating the mongo indexes
     /// </summary>
-    internal class CreateMongoIndexes : Job<object>
+    internal class CreateMongoIndexes : Job
     {
+        public CreateMongoIndexes(string jobUuid)
+            : base(jobUuid)
+        {
+        }
+
         /// <summary>
         /// The main body for the job being run.
         /// </summary>
         protected override void Work()
         {
             var dbFactory = new DbFactory();
-            this.CreateRunnersIndexes(dbFactory);
+            this.AddMessage("Starting to apply indexes");
+            this.CreateRunnersIndexes();
+            this.CreateJobsIndexes();
+            this.CreateJobMessagesIndexes();
+            this.AddMessage("Finished applying indexes");
         }
 
-        private void CreateRunnersIndexes(IDbFactory dbFactory)
+        private void CreateRunnersIndexes()
         {
-            this.AddMessage("Starting to apply indexes");
-            var runnerCol = dbFactory.GetCollection<dynamic>("corp-hq", CollectionNames.Runners);
+            var runnerCol = DbFactory.GetCollection<dynamic>("corp-hq", CollectionNames.Runners);
             runnerCol.Indexes.CreateOne(
                 Builders<dynamic>.IndexKeys.Ascending("expireAt"),
                 new CreateIndexOptions { ExpireAfter = TimeSpan.FromSeconds(0) });
-            this.AddMessage("Finished applying indexes");
+        }
+
+        private void CreateJobsIndexes()
+        {
+            var jobsCol = DbFactory.GetCollection<dynamic>("corp-hq", CollectionNames.Jobs);
+            jobsCol.Indexes.CreateOne(
+                Builders<dynamic>.IndexKeys.Ascending("expireAt"),
+                new CreateIndexOptions { ExpireAfter = TimeSpan.FromSeconds(0) });
+        }
+
+        private void CreateJobMessagesIndexes()
+        {
+            var jobsCol = DbFactory.GetCollection<dynamic>("corp-hq", CollectionNames.JobMessages);
+            jobsCol.Indexes.CreateOne(
+                Builders<dynamic>.IndexKeys.Ascending("expireAt"),
+                new CreateIndexOptions { ExpireAfter = TimeSpan.FromSeconds(0) });
         }
     }
 }

--- a/app/runner/Jobs/IJob.cs
+++ b/app/runner/Jobs/IJob.cs
@@ -17,12 +17,12 @@ namespace Runner.Jobs
     /// Contract for a job in this system.
     /// </summary>
     /// <typeparam name="T">The type of data used by this job.</typeparam>
-    internal interface IJob<T> : IJob
+    public interface IJob<T> : IJob
         where T : class
     {
         /// <summary>
-        /// Sets the data that is associated with this job.
+        /// Gets or sets the data that is associated with this job.
         /// </summary>
-        T Data { set; }
+        T Data { get; set; }
     }
 }

--- a/app/runner/Jobs/ImportMapData.cs
+++ b/app/runner/Jobs/ImportMapData.cs
@@ -16,20 +16,24 @@ namespace Runner.Jobs
     /// <summary>
     /// Job for creating the mongo indexes
     /// </summary>
-    internal class ImportMapData : Job<object>
+    internal class ImportMapData : Job
     {
         private static readonly HttpClient Client = new HttpClient();
+
+        public ImportMapData(string jobUuid)
+            : base(jobUuid)
+        {
+        }
 
         /// <summary>
         /// The main body for the job being run.
         /// </summary>
         protected override void Work()
         {
-            var dbFactory = new DbFactory();
-            this.ImportRegions(dbFactory);
+            this.ImportRegions();
         }
 
-        private void ImportRegions(IDbFactory dbFactory)
+        private void ImportRegions()
         {
             this.AddMessage("Fetching list of regions.");
 
@@ -40,7 +44,7 @@ namespace Runner.Jobs
             var regionsTask = Client.GetStringAsync(uri);
             var regions = JsonConvert.DeserializeObject<List<int>>(regionsTask.Result);
 
-            var regionCol = dbFactory.GetCollection<Region>("corp-hq", CollectionNames.Regions);
+            var regionCol = DbFactory.GetCollection<Region>("corp-hq", CollectionNames.Regions);
             foreach (var regionId in regions)
             {
                 this.AddMessage("Fetching data for region: {0}.", regionId);

--- a/app/runner/Jobs/ImportMapData.cs
+++ b/app/runner/Jobs/ImportMapData.cs
@@ -1,0 +1,83 @@
+// Copyright (c) MadDonkeySoftware
+
+namespace Runner.Jobs
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Diagnostics.CodeAnalysis;
+    using System.Net.Http;
+    using Common.Data;
+    using Common.Model.Eve;
+    using MongoDB.Bson;
+    using MongoDB.Driver;
+    using Newtonsoft.Json;
+    using Newtonsoft.Json.Linq;
+
+    /// <summary>
+    /// Job for creating the mongo indexes
+    /// </summary>
+    internal class ImportMapData : Job<object>
+    {
+        private static readonly HttpClient Client = new HttpClient();
+
+        /// <summary>
+        /// The main body for the job being run.
+        /// </summary>
+        protected override void Work()
+        {
+            var dbFactory = new DbFactory();
+            this.ImportRegions(dbFactory);
+        }
+
+        private void ImportRegions(IDbFactory dbFactory)
+        {
+            this.AddMessage("Fetching list of regions.");
+
+            Client.DefaultRequestHeaders.Accept.Clear();
+            Client.DefaultRequestHeaders.Add("Accept", "application/json");
+
+            var uri = new Uri("https://esi.tech.ccp.is/latest/universe/regions");
+            var regionsTask = Client.GetStringAsync(uri);
+            var regions = JsonConvert.DeserializeObject<List<int>>(regionsTask.Result);
+
+            var regionCol = dbFactory.GetCollection<Region>("corp-hq", CollectionNames.Regions);
+            foreach (var regionId in regions)
+            {
+                this.AddMessage("Fetching data for region: {0}.", regionId);
+                uri = new Uri(string.Concat("https://esi.tech.ccp.is/latest/universe/regions/", regionId));
+                var regionDetailsTask = Client.GetStringAsync(uri);
+                var regionDetails = JsonConvert.DeserializeObject<RegionDetailsData>(regionDetailsTask.Result);
+
+                var regionData = new Region
+                {
+                    BaseId = ObjectId.GenerateNewId(),
+                    RegionId = regionId,
+                    Name = regionDetails.Name,
+                    ConstellationIds = regionDetails.ConstellationIds
+                };
+
+                var filterCondition = Builders<Region>.Filter.Eq(r => r.RegionId, regionId);
+                var updateCondition = Builders<Region>.Update.Set(r => r.RegionId, regionId)
+                                                             .Set(r => r.Name, regionDetails.Name)
+                                                             .Set(r => r.ConstellationIds, regionDetails.ConstellationIds);
+
+                regionCol.UpdateOne(filterCondition, updateCondition, new UpdateOptions { IsUpsert = true });
+            }
+
+            this.AddMessage("Finished importing region data.");
+        }
+
+        [SuppressMessage("Microsoft.Performance", "CA1812:AvoidUninstantiatedInternalClasses", Justification="Used by Newtonsoft.Json")]
+        internal class RegionDetailsData
+        {
+            [JsonProperty("name")]
+            internal string Name { get; set; }
+
+            [JsonProperty("region_id")]
+            internal int RegionId { get; set; }
+
+            [JsonProperty("constellations")]
+            internal List<int> ConstellationIds { get; set; }
+        }
+    }
+}

--- a/app/runner/Jobs/Job.cs
+++ b/app/runner/Jobs/Job.cs
@@ -4,6 +4,7 @@ namespace Runner.Jobs
 {
     using System;
     using System.Collections.Generic;
+    using System.Globalization;
     using Microsoft.Extensions.Logging;
 
     /// <summary>
@@ -67,10 +68,13 @@ namespace Runner.Jobs
         /// <summary>
         /// Associates a message with this job.
         /// </summary>
-        /// <param name="message">The message to associate with the job.</param>
-        protected internal void AddMessage(string message)
+        /// <param name="format">The message format to associate with the job.</param>
+        /// <param name="args">The message args to associate with the job.</param>
+        protected internal void AddMessage(string format, params object[] args)
         {
             // TODO: Eventually these messages should be stored in our data store.
+            var message = string.Format(CultureInfo.CurrentCulture, format, args);
+            Console.WriteLine(message, args);
             this.Messages.Add(message);
         }
 

--- a/app/runner/Model/TaskRunner.cs
+++ b/app/runner/Model/TaskRunner.cs
@@ -17,11 +17,5 @@ namespace Runner.Model
         /// </summary>
         [BsonElement("name")]
         public string Name { get; set; }
-
-        /// <summary>
-        /// Gets or sets the name.
-        /// </summary>
-        [BsonElement("expireAt")]
-        public DateTime ExpireAt { get; set; }
     }
 }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -23,7 +23,7 @@ services:
             - "rabbitmq:rabbit"
     mongodb:
         container_name: "mongodb"
-        image: mongo:latest
+        image: mongo:3.6.3
         environment:
             - MONGO_DATA_DIR=/data/db
             - MONGO_LOG_DIR=/dev/null


### PR DESCRIPTION
### Story
https://maddonkeysoftware.myjetbrains.com/youtrack/issue/CHQ-58

#### Depends On
#15 

### Summary
* Separated `Job` from `JobSpec` to help avoid name collisions
* Added expirary for `Job` and `JobMessages`
* Split Job / JobSpec into to types, one with "data" and one without.
* Expanded `CreateMongoIndexes` job to include Job and JobMessages
* Updated base `Job` class to have member variable for DbFactory. 
  * The intent here is that jobs in the future that contain data will load the data themselves since the job is now aware of it's job uuid.
* Wrapped `Monitor`'s HandleMessage with a try catch so that errors can be printed to the screen and not lost during development.
* Pinned mongo image number to `3.6.3`

### Testing
* Run the import map data job or the create mongo indexes job
* In mongo: `db.jobMessages.Find()` to verify job messages are being saved appropriately.