### PR TITLE
CHQ-25 centered error messages, client side validation works

### DIFF
--- a/app/ui/src/components/LogIn.vue
+++ b/app/ui/src/components/LogIn.vue
@@ -1,10 +1,14 @@
 <template>
   <section class="section">
-    <div v-if="errors.length">
-      <b>{{$t('pleaseCorrectErrors')}}</b>
-      <ul>
-        <li v-for="error in errors" v-bind:key="error">{{ error }}</li>
-      </ul>
+    <div class="columns">
+      <div class="column is-one-fifth"></div>
+        <div class="column is-danger" v-if="errors.length">
+          <b>{{$t('pleaseCorrectErrors')}}</b>
+          <ul>
+            <li v-for="error in errors" v-bind:key="error">{{ error }}</li>
+          </ul>
+        </div>
+      <div class="column is-one-fifth"></div>
     </div>
 
     <div class="columns">
@@ -77,7 +81,6 @@ export default {
       this.submittingLogin = false
     },
     isFormValid () {
-
       if (this.username.length === 0) {
         this.errors.push('Username is a required field.')
       }

--- a/app/ui/src/components/Register.vue
+++ b/app/ui/src/components/Register.vue
@@ -1,10 +1,14 @@
 <template>
   <section class="section">
-    <div v-if="errors.length">
-      <b>{{$t('pleaseCorrectErrors')}}</b>
-      <ul>
-        <li v-for="error in errors" v-bind:key="error">{{ error }}</li>
-      </ul>
+    <div class="columns">
+      <div class="column is-one-fifth"></div>
+        <div class="column" v-if="errors.length">
+            <b>{{$t('pleaseCorrectErrors')}}</b>
+            <ul>
+              <li v-for="error in errors" v-bind:key="error">{{ error }}</li>
+            </ul>
+        </div>
+      <div class="column is-one-fifth"></div>
     </div>
 
     <div class="columns">
@@ -54,7 +58,7 @@
         <div class="field">
           <div class="control">
             <label class="checkbox">
-              <input type="checkbox">
+              <input type="checkbox" :placeholder="$t('agreeWithTermsAndConditions')" v-model="agreeWithTermsAndConditions">
               {{$t('agreeWithTermsAndConditions')}}
               <a href="#">{{$t('reviewTermsAndConditions')}}</a>
             </label>
@@ -84,35 +88,54 @@ export default {
       username: '',
       password: '',
       passwordConfirm: '',
-      email: ''
+      email: '',
+      agreeWithTermsAndConfitions: ''
     }
   },
   methods: {
     submitRegistration () {
       this.errors = []
       this.submittingRegistration = true
-      var data = {
-        username: this.username,
-        password: this.password,
-        passwordConfirm: this.passwordConfirm,
-        email: this.email
-      }
-      axios.post('http://127.0.0.1:5000/api/v1/registration', data)
-        .then(response => {
-          // Json response
-          // var items = []
-          // response.data.forEach(element => {
-          //   items.push(element['value'])
-          // })
-          // this.msg = 'Welcome to your Vue.js App. ' + items.join(', ')
-          this.errors.push('Success!')
-        })
-        .catch(e => {
-          e.response.data['messages'].forEach(message => {
-            this.errors.push(message)
+      if (this.isFormValid()) {
+        var data = {
+          username: this.username,
+          password: this.password,
+          passwordConfirm: this.passwordConfirm,
+          email: this.email
+        }
+        axios.post('http://127.0.0.1:5000/api/v1/registration', data)
+          .then(response => {
+            this.errors.push('Success!')
           })
-        })
+          .catch(e => {
+            e.response.data['messages'].forEach(message => {
+              this.errors.push(message)
+            })
+          })
+      }
       this.submittingRegistration = false
+    },
+    isFormValid () {
+      if (this.username.length === 0) {
+        this.errors.push('Username is a required field.')
+      }
+      if (this.password.length === 0) {
+        this.errors.push('Password is a required field.')
+      }
+      if (this.passwordConfirm.length === 0) {
+        this.errors.push('Password Confirmation is a required field.')
+      }
+      if (this.password !== this.passwordConfirm) {
+        this.errors.push('Password and Password Confirmation must match.')
+      }
+      if (this.email.length === 0) {
+        this.errors.push('Email is a required field.')
+      }
+      if (!this.agreeWithTermsAndConfitions.checked) {
+        this.errors.push('You must agree with the Terms and Conditions to register with this site.')
+      }
+
+      return this.errors.length === 0
     }
   }
 }


### PR DESCRIPTION
### Story
https://maddonkeysoftware.myjetbrains.com/youtrack/issue/CHQ-25

### Summary
* Added client-side validation to Register.vue

### Testing
* make run-api
* make run-ui
* goto localhost:8080/#/Register
* fill in the page incorrectly in different ways
  * passwords don't match
  * missing required fields