### PR TITLE
CHQ-60 Added SmartHttpClient that can retry requests in the event of a 500

### DIFF
--- a/app/runner/Jobs/ImportMapData.cs
+++ b/app/runner/Jobs/ImportMapData.cs
@@ -18,7 +18,7 @@ namespace Runner.Jobs
     /// </summary>
     internal class ImportMapData : Job
     {
-        private static readonly HttpClient Client = new HttpClient();
+        private static readonly SmartHttpClient Client = new SmartHttpClient();
 
         public ImportMapData(string jobUuid)
             : base(jobUuid)
@@ -41,16 +41,16 @@ namespace Runner.Jobs
             Client.DefaultRequestHeaders.Add("Accept", "application/json");
 
             var uri = new Uri("https://esi.tech.ccp.is/latest/universe/regions");
-            var regionsTask = Client.GetStringAsync(uri);
-            var regions = JsonConvert.DeserializeObject<List<int>>(regionsTask.Result);
+            var result = Client.GetWithReties(uri);
+            var regions = JsonConvert.DeserializeObject<List<int>>(result);
 
             var regionCol = DbFactory.GetCollection<Region>("corp-hq", CollectionNames.Regions);
             foreach (var regionId in regions)
             {
                 this.AddMessage("Fetching data for region: {0}.", regionId);
                 uri = new Uri(string.Concat("https://esi.tech.ccp.is/latest/universe/regions/", regionId));
-                var regionDetailsTask = Client.GetStringAsync(uri);
-                var regionDetails = JsonConvert.DeserializeObject<RegionDetailsData>(regionDetailsTask.Result);
+                result = Client.GetWithReties(uri);
+                var regionDetails = JsonConvert.DeserializeObject<RegionDetailsData>(result);
 
                 var regionData = new Region
                 {

--- a/app/runner/Jobs/ImportMarketData.cs
+++ b/app/runner/Jobs/ImportMarketData.cs
@@ -21,7 +21,7 @@ namespace Runner.Jobs
     /// </summary>
     internal class ImportMarketData : Job
     {
-        private static readonly HttpClient Client = new HttpClient();
+        private static readonly SmartHttpClient Client = new SmartHttpClient();
         private IMongoCollection<MarketOrder> marketOrderCol;
 
         public ImportMarketData(string jobUuid)
@@ -76,8 +76,8 @@ namespace Runner.Jobs
                     regionId,
                     id,
                     page));
-                var marketDataTask = Client.GetStringAsync(uri);
-                var marketOrders = JsonConvert.DeserializeObject<List<EveMarketOrder>>(marketDataTask.Result);
+                var result = Client.GetWithReties(uri);
+                var marketOrders = JsonConvert.DeserializeObject<List<EveMarketOrder>>(result);
 
                 foreach (var order in marketOrders)
                 {

--- a/app/runner/SmartHttpClient.cs
+++ b/app/runner/SmartHttpClient.cs
@@ -1,0 +1,93 @@
+// Copyright (c) MadDonkeySoftware
+
+namespace Runner
+{
+    using System;
+    using System.Net.Http;
+    using System.Net.Http.Headers;
+    using System.Threading;
+
+    /// <summary>
+    /// A class representing a job runner within the system.
+    /// </summary>
+    public class SmartHttpClient : IDisposable
+    {
+        private readonly HttpClient client;
+        private bool disposedValue = false; // To detect redundant calls
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="SmartHttpClient"/> class.
+        /// </summary>
+        public SmartHttpClient()
+        {
+            this.client = new HttpClient();
+        }
+
+        /// <summary>
+        /// Gets the headers which should be sent with each request.
+        /// </summary>
+        /// <returns>
+        /// The headers which should be sent with each request.
+        /// </returns>
+        public HttpRequestHeaders DefaultRequestHeaders
+        {
+            get
+            {
+                return this.client.DefaultRequestHeaders;
+            }
+        }
+
+        /// <summary>
+        /// Performs an HTTP get against the resource. Should a HTTP 5XX be returned the
+        /// request will be retried after the delay period has ellapsed.
+        /// </summary>
+        /// <param name="uri">The resource to request.</param>
+        /// <param name="retries">Maximum number of times to try the request.</param>
+        /// <param name="delay">The delay between retries.</param>
+        /// <returns>A string containing the response body.</returns>
+        public string GetWithReties(Uri uri, int retries = 3, int delay = 500)
+        {
+            HttpResponseMessage response = null;
+            var tries = 0;
+            do
+            {
+                if (response != null)
+                {
+                    Thread.Sleep(delay);
+                }
+
+                response = this.client.GetAsync(uri).Result;
+                tries += 1;
+            }
+            while ((int)response.StatusCode >= 500 && tries < retries);
+
+            return response.Content.ReadAsStringAsync().Result;
+        }
+
+        /// <summary>
+        /// Releases the unmanaged resources and disposes of the managed resources used by the RequestHelper.
+        /// </summary>
+        public void Dispose()
+        {
+            this.Dispose(true);
+            GC.SuppressFinalize(this);
+        }
+
+        /// <summary>
+        /// Releases the unmanaged resources and disposes of the managed resources used by the RequestHelper.
+        /// </summary>
+        /// <param name="disposing">true if cleaning up managed and unmanaged resources, false if only unmanaged resources.</param>
+        protected virtual void Dispose(bool disposing)
+        {
+            if (!this.disposedValue)
+            {
+                if (disposing)
+                {
+                    this.client.Dispose();
+                }
+
+                this.disposedValue = true;
+            }
+        }
+    }
+}


### PR DESCRIPTION
### Story
https://maddonkeysoftware.myjetbrains.com/youtrack/issue/CHQ-60

### Summary
* Added `SmartHttpClient` class an implemented http get retry logic.
* Modified jobs `ImportMapData` and `ImportMarketData` to use new `SmartHttpClient`

### Testing
* Stop current corp-hq-runner if one is running
* Queue'd about 4 or 5 market data jobs with curl below.
* Set breakpoint in `SmartHttpClient` on `Thread.Sleep` line
* Started corp-hq-runner and verified that breakpoint eventually got hit. Pressed "continue" to let app run.
* Verified debug output that no item types were skipped.