### PR TITLE
CHQ-83 Added ability for database to be named anything on the server

### DIFF
--- a/app/api/Controllers/V1/AuthenticationController.cs
+++ b/app/api/Controllers/V1/AuthenticationController.cs
@@ -58,7 +58,7 @@ namespace Api.Controllers.V1
             }
 
             this.logger.LogDebug(1001, "Authenticating user.");
-            var userCol = this.dbFactory.GetCollection<User>("corp-hq", CollectionNames.Users);
+            var userCol = this.dbFactory.GetCollection<User>(CollectionNames.Users);
             var user = userCol.AsQueryable<User>().Where(u => u.Username == authDetails.Username).FirstOrDefault();
 
             if (user != null)
@@ -69,7 +69,7 @@ namespace Api.Controllers.V1
 
                 if (SecurityHelpers.CompareByteArrays(hashed, submittedHash))
                 {
-                    var sessionCol = this.dbFactory.GetCollection<UserSession>("corp-hq", CollectionNames.Sessions);
+                    var sessionCol = this.dbFactory.GetCollection<UserSession>(CollectionNames.Sessions);
                     var token = SecurityHelpers.GetToken();
                     var remote = this.HttpContext.Connection.RemoteIpAddress.ToString();
 

--- a/app/api/Controllers/V1/JobController.cs
+++ b/app/api/Controllers/V1/JobController.cs
@@ -52,7 +52,7 @@ namespace Api.Controllers.V1
         [HttpGet("status/{jobUuid}")]
         public IActionResult GetStatus(string jobUuid)
         {
-            var jobCol = this.dbFactory.GetCollectionAsQueryable<JobSpecLite>("corp-hq", CollectionNames.Jobs);
+            var jobCol = this.dbFactory.GetCollectionAsQueryable<JobSpecLite>(CollectionNames.Jobs);
             var status = jobCol.Where(j => j.Uuid == jobUuid).Select(j => j.Status).FirstOrDefault();
 
             if (string.IsNullOrEmpty(status))
@@ -73,7 +73,7 @@ namespace Api.Controllers.V1
         [HttpGet("{jobUuid}")]
         public IActionResult Get(string jobUuid)
         {
-            var jobCol = this.dbFactory.GetCollectionAsQueryable<JobSpec<dynamic>>("corp-hq", CollectionNames.Jobs);
+            var jobCol = this.dbFactory.GetCollectionAsQueryable<JobSpec<dynamic>>(CollectionNames.Jobs);
             var jobSpec = jobCol.Where(j => j.Uuid == jobUuid).Select(j => new { Status = j.Status, Type = j.Type, Start = j.StartTimestamp, End = j.EndTimestamp }).FirstOrDefault();
 
             if (jobSpec == null)
@@ -83,7 +83,7 @@ namespace Api.Controllers.V1
                 return this.NotFound(respData);
             }
 
-            var messagesCol = this.dbFactory.GetCollectionAsQueryable<JobMessage>("corp-hq", CollectionNames.JobMessages);
+            var messagesCol = this.dbFactory.GetCollectionAsQueryable<JobMessage>(CollectionNames.JobMessages);
             var messages = messagesCol.Where(m => m.JobUuid == jobUuid).OrderBy(x => x.Timestamp).Select(m => m.Message).ToList();
 
             var details = new JobDetails
@@ -115,7 +115,7 @@ namespace Api.Controllers.V1
         {
             this.logger.LogDebug(1001, "Adding new job to the queue.");
             var newJobUuid = Guid.NewGuid();
-            var col = this.dbFactory.GetCollection<JobSpec<string>>("corp-hq", CollectionNames.Jobs);
+            var col = this.dbFactory.GetCollection<JobSpec<string>>(CollectionNames.Jobs);
 
             var messages = VerifyJobType(jobDetails.JobType);
             if (messages.Count() > 0)

--- a/app/api/Controllers/V1/RegistrationController.cs
+++ b/app/api/Controllers/V1/RegistrationController.cs
@@ -61,7 +61,7 @@ namespace Api.Controllers.V1
             }
 
             // get Action specific errors
-            var col = this.dbFactory.GetCollection<User>("corp-hq", "users");
+            var col = this.dbFactory.GetCollection<User>(CollectionNames.Users);
             errors = ValidateUserRegistrationBody(newUser, col);
             if (errors.Any())
             {

--- a/app/api/Model/Data/SmartConnectionFactory.cs
+++ b/app/api/Model/Data/SmartConnectionFactory.cs
@@ -31,7 +31,7 @@ namespace Api.Model.Data
                     if (rabbitSettings == null)
                     {
                         var dbFactory = new DbFactory();
-                        var settingsCol = dbFactory.GetCollection<Common.Model.Setting<Common.Model.RabbitMQ.Root>>("corp-hq", CollectionNames.Settings);
+                        var settingsCol = dbFactory.GetCollection<Common.Model.Setting<Common.Model.RabbitMQ.Root>>(CollectionNames.Settings);
                         var settings = settingsCol.AsQueryable().Where(s => s.Key == "rabbitConnection").First().Value;
                         rabbitSettings = settings;
                     }

--- a/app/common/Data/DbFactory.cs
+++ b/app/common/Data/DbFactory.cs
@@ -14,6 +14,7 @@ namespace Common.Data
     public class DbFactory : IDbFactory
     {
         private static IMongoClient client;
+        private static string database;
 
         /// <summary>
         /// Gets the mongo client.
@@ -25,7 +26,7 @@ namespace Common.Data
             {
                 if (TestClient != null)
                 {
-                    return (MongoClient)TestClient;
+                    return TestClient;
                 }
 
                 if (DbFactory.client == null)
@@ -38,39 +39,68 @@ namespace Common.Data
             }
         }
 
-        internal static object TestClient { get; set; }
+        public string Database
+        {
+            get
+            {
+                if (TestDatabase != null)
+                {
+                    return TestDatabase;
+                }
+
+                if (string.IsNullOrEmpty(DbFactory.database))
+                {
+                    DbFactory.database = Environment.GetEnvironmentVariable("MONGO_DATABASE") ?? "corp-hq";
+                }
+
+                return DbFactory.database;
+            }
+        }
+
+        internal static IMongoClient TestClient { get; set; }
+        internal static string TestDatabase { get; set; }
 
         /// <summary>
         /// Gets the underlying mongo collection for the provided information.
         /// </summary>
-        /// <param name="databaseName">The mongo database to connect to.</param>
         /// <param name="collectionName">The collection in the corresponding mongo database.</param>
+        /// <param name="databaseName">An optional mongo database to connect to. Defaults to provided environment variable</param>
         /// <param name="client">An optional client with which to connect.</param>
         /// <typeparam name="T">The type of data that this collection houses.</typeparam>
+        /// <remarks>
+        /// Use the optional "databaseName" if the intent is to connect to a database other that what was provided during application startup.
+        /// </remarks>
         /// <returns>A <see cref="IMongoCollection{T}"/>.</returns>
-        public IMongoCollection<T> GetCollection<T>(string databaseName, string collectionName, IMongoClient client = null)
+        public IMongoCollection<T> GetCollection<T>(string collectionName, string databaseName = null, IMongoClient client = null)
         {
             if (client == null)
             {
-                client = DbFactory.client;
+                client = this.Client;
             }
 
-            var db = client.GetDatabase(databaseName);
-            return db.GetCollection<T>(collectionName);
+            if (string.IsNullOrEmpty(databaseName))
+            {
+                databaseName = this.Database;
+            }
+
+            return client.GetDatabase(databaseName).GetCollection<T>(collectionName);
         }
 
         /// <summary>
         /// Gets the underlying mongo collection for the provided information in Queryable mode.
         /// </summary>
-        /// <param name="databaseName">The mongo database to connect to.</param>
         /// <param name="collectionName">The collection in the corresponding mongo database.</param>
+        /// <param name="databaseName">An optional mongo database to connect to.</param>
         /// <param name="client">An optional client with which to connect.</param>
         /// <param name="aggregateOptions">An optional set of aggretation options for the queryable call.</param>
         /// <typeparam name="T">The type of data that this collection houses.</typeparam>
-        /// <returns>A <see cref="IQueryable{T}"/>.</returns>
-        public IQueryable<T> GetCollectionAsQueryable<T>(string databaseName, string collectionName, IMongoClient client = null, AggregateOptions aggregateOptions = null)
+        /// <remarks>
+        /// Use the optional "databaseName" if the intent is to connect to a database other that what was provided during application startup.
+        /// </remarks>
+        /// <returns>A <see cref="IMongoQueryable{T}"/>.</returns>
+        public IQueryable<T> GetCollectionAsQueryable<T>(string collectionName, string databaseName = null, IMongoClient client = null, AggregateOptions aggregateOptions = null)
         {
-            var col = this.GetCollection<T>(databaseName, collectionName, client);
+            var col = this.GetCollection<T>(collectionName, databaseName, client);
             return col.AsQueryable(aggregateOptions);
         }
 

--- a/app/common/Data/IDbFactory.cs
+++ b/app/common/Data/IDbFactory.cs
@@ -22,22 +22,28 @@ namespace Common.Data
         /// <summary>
         /// Gets the underlying mongo collection for the provided information.
         /// </summary>
-        /// <param name="databaseName">The mongo database to connect to.</param>
         /// <param name="collectionName">The collection in the corresponding mongo database.</param>
+        /// <param name="databaseName">An optional mongo database to connect to. Defaults to provided environment variable</param>
         /// <param name="client">An optional client with which to connect.</param>
         /// <typeparam name="T">The type of data that this collection houses.</typeparam>
+        /// <remarks>
+        /// Use the optional "databaseName" if the intent is to connect to a database other that what was provided during application startup.
+        /// </remarks>
         /// <returns>A <see cref="IMongoCollection{T}"/>.</returns>
-        IMongoCollection<T> GetCollection<T>(string databaseName, string collectionName, IMongoClient client = null);
+        IMongoCollection<T> GetCollection<T>(string collectionName, string databaseName = null, IMongoClient client = null);
 
         /// <summary>
         /// Gets the underlying mongo collection for the provided information in Queryable mode.
         /// </summary>
-        /// <param name="databaseName">The mongo database to connect to.</param>
         /// <param name="collectionName">The collection in the corresponding mongo database.</param>
+        /// <param name="databaseName">An optional mongo database to connect to.</param>
         /// <param name="client">An optional client with which to connect.</param>
         /// <param name="aggregateOptions">An optional set of aggretation options for the queryable call.</param>
         /// <typeparam name="T">The type of data that this collection houses.</typeparam>
+        /// <remarks>
+        /// Use the optional "databaseName" if the intent is to connect to a database other that what was provided during application startup.
+        /// </remarks>
         /// <returns>A <see cref="IMongoQueryable{T}"/>.</returns>
-        IQueryable<T> GetCollectionAsQueryable<T>(string databaseName, string collectionName, IMongoClient client = null, AggregateOptions aggregateOptions = null);
+        IQueryable<T> GetCollectionAsQueryable<T>(string collectionName, string databaseName = null, IMongoClient client = null, AggregateOptions aggregateOptions = null);
     }
 }

--- a/app/runner/Jobs/CreateMongoIndexes.cs
+++ b/app/runner/Jobs/CreateMongoIndexes.cs
@@ -32,7 +32,7 @@ namespace Runner.Jobs
 
         private void CreateRunnersIndexes()
         {
-            var col = DbFactory.GetCollection<dynamic>("corp-hq", CollectionNames.Runners);
+            var col = DbFactory.GetCollection<dynamic>(CollectionNames.Runners);
             col.Indexes.CreateOne(
                 Builders<dynamic>.IndexKeys.Ascending("expireAt"),
                 new CreateIndexOptions { ExpireAfter = TimeSpan.FromSeconds(0) });
@@ -40,7 +40,7 @@ namespace Runner.Jobs
 
         private void CreateJobsIndexes()
         {
-            var col = DbFactory.GetCollection<dynamic>("corp-hq", CollectionNames.Jobs);
+            var col = DbFactory.GetCollection<dynamic>(CollectionNames.Jobs);
             col.Indexes.CreateOne(
                 Builders<dynamic>.IndexKeys.Ascending("expireAt"),
                 new CreateIndexOptions { ExpireAfter = TimeSpan.FromSeconds(0) });
@@ -48,7 +48,7 @@ namespace Runner.Jobs
 
         private void CreateJobMessagesIndexes()
         {
-            var col = DbFactory.GetCollection<dynamic>("corp-hq", CollectionNames.JobMessages);
+            var col = DbFactory.GetCollection<dynamic>(CollectionNames.JobMessages);
             col.Indexes.CreateOne(
                 Builders<dynamic>.IndexKeys.Ascending("expireAt"),
                 new CreateIndexOptions { ExpireAfter = TimeSpan.FromSeconds(0) });
@@ -56,7 +56,7 @@ namespace Runner.Jobs
 
         private void CreateMarketOrdersIndexes()
         {
-            var col = DbFactory.GetCollection<dynamic>("corp-hq", CollectionNames.MarketOrders);
+            var col = DbFactory.GetCollection<dynamic>(CollectionNames.MarketOrders);
             col.Indexes.CreateOne(
                 Builders<dynamic>.IndexKeys.Ascending("expireAt"),
                 new CreateIndexOptions { ExpireAfter = TimeSpan.FromSeconds(0) });
@@ -64,7 +64,7 @@ namespace Runner.Jobs
 
         private void CreateSessionIndexes()
         {
-            var col = DbFactory.GetCollection<dynamic>("corp-hq", CollectionNames.Sessions);
+            var col = DbFactory.GetCollection<dynamic>(CollectionNames.Sessions);
             col.Indexes.CreateOne(
                 Builders<dynamic>.IndexKeys.Ascending("expireAt"),
                 new CreateIndexOptions { ExpireAfter = TimeSpan.FromSeconds(0) });

--- a/app/runner/Jobs/ImportMapData.cs
+++ b/app/runner/Jobs/ImportMapData.cs
@@ -44,7 +44,7 @@ namespace Runner.Jobs
             var result = Client.GetWithReties(uri);
             var regions = JsonConvert.DeserializeObject<List<int>>(result);
 
-            var regionCol = DbFactory.GetCollection<Region>("corp-hq", CollectionNames.Regions);
+            var regionCol = DbFactory.GetCollection<Region>(CollectionNames.Regions);
             foreach (var regionId in regions)
             {
                 this.AddMessage("Fetching data for region: {0}.", regionId);

--- a/app/runner/Jobs/ImportMarketData.cs
+++ b/app/runner/Jobs/ImportMarketData.cs
@@ -36,7 +36,7 @@ namespace Runner.Jobs
         {
             this.AddMessage("Starting market data import.");
 
-            var jobCol = DbFactory.GetCollection<JobSpec<string>>("corp-hq", CollectionNames.Jobs);
+            var jobCol = DbFactory.GetCollection<JobSpec<string>>(CollectionNames.Jobs);
             var jobData = jobCol.AsQueryable().Where(j => j.Uuid == this.JobUuid).Select(j => j.Data).FirstOrDefault();
 
             if (string.IsNullOrEmpty(jobData))
@@ -54,7 +54,7 @@ namespace Runner.Jobs
         {
             Client.DefaultRequestHeaders.Accept.Clear();
             Client.DefaultRequestHeaders.Add("Accept", "application/json");
-            this.marketOrderCol = DbFactory.GetCollection<MarketOrder>("corp-hq", CollectionNames.MarketOrders);
+            this.marketOrderCol = DbFactory.GetCollection<MarketOrder>(CollectionNames.MarketOrders);
 
             foreach (var id in jobData.MarketTypeIds)
             {

--- a/app/runner/Jobs/Job.cs
+++ b/app/runner/Jobs/Job.cs
@@ -46,8 +46,8 @@ namespace Runner.Jobs
         {
             try
             {
-                this.messageCollection = DbFactory.GetCollection<JobMessage>("corp-hq", CollectionNames.JobMessages);
-                this.jobSpecCollection = DbFactory.GetCollection<JobSpec<dynamic>>("corp-hq", CollectionNames.Jobs);
+                this.messageCollection = DbFactory.GetCollection<JobMessage>(CollectionNames.JobMessages);
+                this.jobSpecCollection = DbFactory.GetCollection<JobSpec<dynamic>>(CollectionNames.Jobs);
                 this.Initialize();
                 this.Work();
                 this.Conclude();

--- a/app/runner/Monitor.cs
+++ b/app/runner/Monitor.cs
@@ -23,7 +23,6 @@ namespace Runner
     /// </summary>
     public class Monitor : IDisposable
     {
-        private const string DbName = "corp-hq";
         private static readonly object Padlock = new object();
         private static Monitor instance = null;
         private static IConnectionFactory connectionFactory;
@@ -74,7 +73,7 @@ namespace Runner
         /// </summary>
         public void Start()
         {
-            var settingsCollection = dbFactory.GetCollection<Common.Model.Setting<Common.Model.RabbitMQ.Root>>(DbName, CollectionNames.Settings);
+            var settingsCollection = dbFactory.GetCollection<Common.Model.Setting<Common.Model.RabbitMQ.Root>>(CollectionNames.Settings);
             var settings = settingsCollection.AsQueryable().Where(s => s.Key == "rabbitConnection").First().Value;
 
             connectionFactory.UserName = settings.Username;
@@ -95,7 +94,7 @@ namespace Runner
                 arguments: null);
 
             // Add ourself to the runner collection
-            var col = dbFactory.GetCollection<TaskRunner>(DbName, CollectionNames.Runners);
+            var col = dbFactory.GetCollection<TaskRunner>(CollectionNames.Runners);
             col.InsertOne(new TaskRunner { Name = this.controlQueueName, ExpireAt = DateTime.Now.AddMinutes(settings.RecordTtl) });
 
             // Setup heartbeat
@@ -175,7 +174,7 @@ namespace Runner
                 Thread.Sleep(1000);
             }
 
-            var col = dbFactory.GetCollection<TaskRunner>(DbName, CollectionNames.Runners);
+            var col = dbFactory.GetCollection<TaskRunner>(CollectionNames.Runners);
             col.FindOneAndDelete(r => r.Name == this.controlQueueName);
             this.Dispose();
         }
@@ -188,7 +187,7 @@ namespace Runner
                 Console.WriteLine(" [x] Received  {0}", uuid);
 
                 /* TODO: Actual job processing logic here. */
-                var col = dbFactory.GetCollection<JobSpec<object>>(DbName, CollectionNames.Jobs);
+                var col = dbFactory.GetCollection<JobSpec<object>>(CollectionNames.Jobs);
 
                 var jobSpec = col.AsQueryable().Where(j => j.Uuid == uuid)
                                                .Select(j => new JobSpecLite { Uuid = j.Uuid, Type = j.Type })

--- a/tests/unit/apitest/Controllers/JobControllerTest.cs
+++ b/tests/unit/apitest/Controllers/JobControllerTest.cs
@@ -192,7 +192,7 @@ namespace ApiTests.Controllers
         public void CorrectJobStatus(string jobUuid, IQueryable<JobSpecLite> queryable, int expectedStatus, JobStatus expectedData)
         {
             // Arrange
-            this.dbFactoryMock.Setup(x => x.GetCollectionAsQueryable<JobSpecLite>("corp-hq", CollectionNames.Jobs, null, null)).Returns(queryable);
+            this.dbFactoryMock.Setup(x => x.GetCollectionAsQueryable<JobSpecLite>(CollectionNames.Jobs, null, null, null)).Returns(queryable);
 
             // Act
             var result = (ObjectResult)this.Controller.GetStatus(jobUuid);
@@ -213,8 +213,8 @@ namespace ApiTests.Controllers
             JobDetails expectedData)
         {
             // Arrange
-            this.dbFactoryMock.Setup(x => x.GetCollectionAsQueryable<JobSpec<dynamic>>("corp-hq", CollectionNames.Jobs, null, null)).Returns(jobsQueryable);
-            this.dbFactoryMock.Setup(x => x.GetCollectionAsQueryable<JobMessage>("corp-hq", CollectionNames.JobMessages, null, null)).Returns(messagesQueryable);
+            this.dbFactoryMock.Setup(x => x.GetCollectionAsQueryable<JobSpec<dynamic>>(CollectionNames.Jobs, null, null, null)).Returns(jobsQueryable);
+            this.dbFactoryMock.Setup(x => x.GetCollectionAsQueryable<JobMessage>(CollectionNames.JobMessages, null, null, null)).Returns(messagesQueryable);
 
             // Act
             var result = (ObjectResult)this.Controller.Get(jobUuid);
@@ -234,7 +234,7 @@ namespace ApiTests.Controllers
             var mockRabbitConnection = new Mock<IConnection>();
             var mockRabbitChannel = new Mock<IModel>();
 
-            this.dbFactoryMock.Setup(x => x.GetCollection<JobSpec<string>>("corp-hq", CollectionNames.Jobs, null)).Returns(mockCollection.Object);
+            this.dbFactoryMock.Setup(x => x.GetCollection<JobSpec<string>>(CollectionNames.Jobs, null, null)).Returns(mockCollection.Object);
             this.connectionFactoryMock.Setup(x => x.CreateConfiguredConnection()).Returns(mockRabbitConnection.Object);
             mockRabbitConnection.Setup(x => x.CreateModel()).Returns(mockRabbitChannel.Object);
 


### PR DESCRIPTION
### Story
https://maddonkeysoftware.myjetbrains.com/youtrack/issue/CHQ-83

### Summary
* Updated `IDbFactory` and `DbFactory` methods `GetCollection` and `GetCollectionAsQueryable`  to change database name from a required to an optional parameter
* Updated all references of `GetCollection` and `GetCollectionAsQueryable` to no longer use explicitly specified db name

### Testing
* Start the app and poke around a bit as normal. Schedule a job and verify you can read the result or anything like that. The functionality before and after edits is identical.