### PR TITLE
CHQ-96 Allow logout from application

### DIFF
--- a/app/api/Controllers/V1/TokenController.cs
+++ b/app/api/Controllers/V1/TokenController.cs
@@ -1,0 +1,80 @@
+// Copyright (c) MadDonkeySoftware
+
+namespace Api.Controllers.V1
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Threading.Tasks;
+
+    using Api.Extensions;
+    using Api.Model;
+    using Api.Model.Data;
+    using Common.Data;
+    using Microsoft.AspNetCore.Mvc;
+    using Microsoft.Extensions.Logging;
+    using MongoDB.Bson;
+    using MongoDB.Driver;
+
+    /// <summary>
+    /// Controller for Registration actions.
+    /// </summary>
+    [V1Route]
+    public class TokenController : Controller
+    {
+        private readonly ILogger logger;
+        private readonly IDbFactory dbFactory;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="TokenController"/> class.
+        /// </summary>
+        /// <param name="logger">The logger in which to use.</param>
+        /// <param name="dbFactory">The factory for DB connections.</param>
+        public TokenController(ILogger<TokenController> logger, IDbFactory dbFactory)
+        {
+            this.logger = logger;
+            this.dbFactory = dbFactory;
+        }
+
+        /// <summary>
+        /// The PUT verb handler
+        /// </summary>
+        /// <param name="token">The token being refreshed.</param>
+        /// <returns>No Content</returns>
+        /// <remarks>
+        /// PUT api/v1/token/{id}
+        /// </remarks>
+        [HttpPut("{token}")]
+        public ActionResult Post(string token)
+        {
+            this.logger.LogDebug(1001, "Refreshing token.");
+            var sessionCol = this.dbFactory.GetCollection<UserSession>(CollectionNames.Sessions);
+
+            var filterCondition = Builders<UserSession>.Filter.Eq(s => s.Key, token);
+            var updateCondition = Builders<UserSession>.Update.Set(s => s.ExpireAt, DateTime.Now.AddMinutes(30));
+            sessionCol.UpdateOne(filterCondition, updateCondition, new UpdateOptions { IsUpsert = false });
+
+            return this.NoContent();
+        }
+
+        /// <summary>
+        /// The DELETE verb handler
+        /// </summary>
+        /// <param name="token">The token being removed.</param>
+        /// <returns>No Content</returns>
+        /// <remarks>
+        /// DELETE api/v1/token/{id}
+        /// </remarks>
+        [HttpDelete("{token}")]
+        public ActionResult Delete(string token)
+        {
+            this.logger.LogDebug(1001, "Removing token.");
+            var sessionCol = this.dbFactory.GetCollection<UserSession>(CollectionNames.Sessions);
+
+            var filterCondition = Builders<UserSession>.Filter.Eq(s => s.Key, token);
+            sessionCol.DeleteOne(filterCondition);
+
+            return this.NoContent();
+        }
+    }
+}

--- a/app/ui/package.json
+++ b/app/ui/package.json
@@ -13,6 +13,10 @@
     "lint": "eslint --ext .js,.vue src test/unit test/e2e/specs",
     "build": "node build/build.js"
   },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/MadDonkeySoftware/corp-hq"
+  },
   "dependencies": {
     "axios": "^0.18.0",
     "bulma": "^0.6.2",

--- a/app/ui/src/constants.js
+++ b/app/ui/src/constants.js
@@ -1,0 +1,4 @@
+// Not sure if this is the "javascript-y" way to do this...
+export default {
+  authTokenUpdated: 'authTokenUpdated'
+}

--- a/app/ui/src/main.js
+++ b/app/ui/src/main.js
@@ -6,6 +6,22 @@ import App from './App'
 import router from './router'
 import vuexI18n from 'vuex-i18n'
 import translationsEn from './i18n/en'
+import constants from '@/constants'
+
+// Set up a global mechanism to pass events
+window.Event = new class {
+  constructor () {
+    this.vue = new Vue()
+  }
+
+  fire (event, data = null) {
+    this.vue.$emit(event, data)
+  }
+
+  listen (event, callback) {
+    this.vue.$on(event, callback)
+  }
+}()
 
 Vue.config.productionTip = false
 
@@ -23,5 +39,14 @@ new Vue({
   el: '#app',
   router,
   components: { App },
-  template: '<App/>'
+  template: '<App/>',
+  mounted () {
+    Event.listen(constants.authTokenUpdated, function (value) {
+      if (value == null || value === undefined) {
+        localStorage.removeItem('token')
+      } else {
+        localStorage.setItem('token', value)
+      }
+    })
+  }
 })

--- a/app/ui/src/pages/LogIn.vue
+++ b/app/ui/src/pages/LogIn.vue
@@ -48,6 +48,7 @@
 
 <script>
 import axios from 'axios'
+import constants from '@/constants'
 
 export default {
   name: 'Register',
@@ -70,7 +71,7 @@ export default {
         }
         axios.post('http://127.0.0.1:5000/api/v1/authentication', data)
           .then(response => {
-            localStorage.setItem('token', response.data['token'])
+            Event.fire(constants.authTokenUpdated, response.data['token'])
             this.$router.push({name: 'Dashboard', params: { userId: 123 }})
           })
           .catch(e => {

--- a/behave-ci-cd.sh
+++ b/behave-ci-cd.sh
@@ -39,7 +39,7 @@ echo "-----------"
 echo "Sleeping then starting the tests."
 echo "-----------"
 sleep 2
-docker run -it -v $(pwd)/tests/behavior:/home/node/app -w="/home/node/app" --network="test-network" --name test-node node:8 bash -c "npm install; API_URL=http://test-api MONGO_URL=mongodb://test-mongodb:27017/auth npm run cucumber"
+docker run -it --rm -v $(pwd)/tests/behavior:/home/node/app -w="/home/node/app" --network="test-network" --name test-node node:8 bash -c "npm install; API_URL=http://test-api MONGO_URL=mongodb://test-mongodb:27017/auth npm run cucumber -- --tags 'not @ignore'"
 EXIT_CODE="$(docker inspect --format='{{.State.ExitCode}}' test-node)"
 
 echo "-----------"
@@ -49,7 +49,6 @@ if [ "$1" = "debug" ] && [ "$EXIT_CODE" != "0" ]; then
     echo "Not cleaning up containers or volumes since debug mode is on and there was an error. Run 'docker-compose -f test-compose.yml down -v' to clean up containers."
 else
     docker-compose -f test-compose.yml down -v
-    docker rm test-node -v
 fi
 
 # Helpful commands for debugging.

--- a/tests/behavior/features/authentication.feature
+++ b/tests/behavior/features/authentication.feature
@@ -1,0 +1,10 @@
+@ignore
+Feature: Authentication
+
+  Verify that authentication in the system works appropriately
+
+  Scenario: API authenticate provides new token
+    Given I do not have an auth token
+    When I authenticate to the system
+    Then I have an auth token
+    And a session exists in the system for my token

--- a/tests/behavior/features/step_definitions/token.js
+++ b/tests/behavior/features/step_definitions/token.js
@@ -1,0 +1,362 @@
+const {Given, When, Then} = require('cucumber')
+const assert = require('assert')
+const request = require('request')
+const {MongoClient} = require('mongodb')
+
+const defaultDelta = 30 * 60 * 1000  // 30 minutes
+let getExpiryTime = function (futureDelta = defaultDelta) {
+    return new Date(new Date().getTime() + futureDelta)
+}
+let generateToken = function (length = 40) {
+    var text = ''
+    var possible = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789'
+  
+    for (var i = 0; i < length; i++) {
+      text += possible.charAt(Math.floor(Math.random() * possible.length))
+    }
+
+    return text
+  }
+
+Given('I already have an auth token expiring in {int} seconds', function (expireSeconds, callback) {
+    this.token = generateToken()
+    this.tokenExpirary = getExpiryTime(expireSeconds * 1000)
+    let test = this
+    MongoClient.connect(test.mongoUrl, function(err, db) {
+        try {
+            if (err) callback(err)
+            let dbo = db.db(test.appDb)
+            let dbc = dbo.collection('sessions')
+            let item = {
+                'expireAt': test.tokenExpirary,
+                'key': test.token,
+                'username': 'testUser',
+                'endpiont': '127.0.0.1'
+            }
+
+            // clear the collection
+            dbc.insertOne(item)
+
+            callback()
+        }
+        catch(err){
+            callback(err);
+        }
+        finally{
+            db.close()
+        }
+    });
+});
+
+When('I log out of the system', function (callback) {
+    let test = this
+    let args = {
+        method: 'DELETE',
+        uri: this.v1Url('token/' + test.token),
+        json: true
+    }
+
+    request(args, (err, response, body) => {
+        if (err) {
+            callback(err);
+        } else {
+            test.respCode = response.statusCode;
+            callback();
+        }
+    });
+});
+
+When('I refresh the token with the system', function (callback) {
+    let test = this
+    let args = {
+        method: 'PUT',
+        uri: this.v1Url('token/' + test.token),
+        json: true
+    }
+
+    request(args, (err, response, body) => {
+        if (err) {
+            callback(err);
+        } else {
+            test.respCode = response.statusCode;
+            callback();
+        }
+    });
+});
+
+Then('a session no longer exists in the system for my token', function (callback) {
+    let test = this
+    MongoClient.connect(test.mongoUrl, function(err, db) {
+        try {
+            if (err) callback(err)
+            let dbo = db.db(test.appDb)
+            let dbc = dbo.collection('sessions')
+            let query = { 'key': test.token }
+
+            dbc.count(query).then(function (count){
+                assert.equal(count, 0)
+                callback()
+            }).catch(function (reason) {
+                callback('Failed: ' + reason)
+            })
+
+        }
+        catch(err){
+            callback(err);
+        }
+        finally{
+            db.close()
+        }
+    });
+})
+
+Then('the session for my token has an updated exipration timestamp', function (callback) {
+    let test = this
+    MongoClient.connect(test.mongoUrl, function(err, db) {
+        try {
+            if (err) callback(err)
+            let dbo = db.db(test.appDb)
+            let dbc = dbo.collection('sessions')
+            let query = { 'key': test.token }
+
+            dbc.findOne(query).then(function (sessionDocument) {
+                if (sessionDocument['expireAt'] <= test.tokenExpirary) {
+                    assert.fail('Token expireAt not updated')
+                }
+                callback()
+            }).catch(function (reason) {
+                callback('Failed: ' + reason)
+            })
+        }
+        catch(err){
+            callback(err);
+        }
+        finally{
+            db.close()
+        }
+    });
+})
+
+/*
+Given('there is no market data in the system', function (callback) {
+    let test = this
+    MongoClient.connect(test.mongoUrl, function(err, db) {
+        try {
+            if (err) callback(err)
+            let dbo = db.db(test.appDb)
+            let dbc = dbo.collection('marketOrders')
+            let query = { }
+
+            // clear the collection
+            dbc.deleteMany(query)
+
+            callback()
+        }
+        catch(err){
+            callback(err);
+        }
+        finally{
+            db.close()
+        }
+    });
+});
+
+Given('there is map data in the database', function (callback) {
+    let test = this
+    MongoClient.connect(test.mongoUrl, function(err, db) {
+        try {
+            if (err) callback(err)
+            let dbo = db.db(test.appDb)
+            let dbc = dbo.collection('regions')
+            let regionIds = [ 10000001, 10000002, 10000003, 10000004, 10000005, 10000006, 10000007, 10000008, 10000009, 10000010 ]
+            let items = []
+
+            for (let i = 0; i < regionIds.length; i++) {
+                let id = regionIds[i]
+                items.push({ 
+                    "constellationIds": [],
+                    "name": "Region" + id,
+                    "regionId": parseInt(id)
+                })
+            }
+
+            // clear the collection
+            dbc.deleteMany({})
+            dbc.insertMany(items)
+
+            callback()
+        }
+        catch(err){
+            callback(err);
+        }
+        finally{
+            db.close()
+        }
+    });
+});
+
+Given('there is market data in the system for item {int}', function (type_id, callback) {
+    let test = this
+    MongoClient.connect(test.mongoUrl, function(err, db) {
+        try {
+            if (err) callback(err)
+            let dbo = db.db(test.appDb)
+            let dbc = dbo.collection('marketOrders')
+            let maxItems = 1000;
+            let issued = new Date().toISOString().split(".")[0] + "Z";
+            let items = []
+
+            for(let i = 0; i < maxItems; i++) {
+                items.push({
+                    "duration": 30,
+                    "is_buy_order": false,
+                    "issued": issued,
+                    "location_id": 60005785,
+                    "min_volume": 1,
+                    "order_id": i + 1000,
+                    "price": 5.7,
+                    "range": "region",
+                    "system_id": 30002048,
+                    "type_id": parseInt(type_id),
+                    "volume_remain": 10250,
+                    "volume_total": 10250
+                })
+            }
+
+            // clear the collection
+            dbc.deleteMany({})
+            dbc.insertMany(items)
+
+            callback()
+        }
+        catch(err){
+            callback(err);
+        }
+        finally{
+            db.close()
+        }
+    });
+});
+
+When('I schedule the {string} job', function (job, callback) {
+    // TODO: Get this working with promises.
+    // NOTE: I tried to get this working with promises but I kept getting an error
+    // about missing the 'render' on undefined... I used examples from
+    // https://www.sitepoint.com/bdd-javascript-cucumber-gherkin/
+    let test = this
+    let args = {
+        method: 'POST',
+        uri: this.v1Url('job'),
+        json: true,
+        body: {
+            "jobType": jobMap[job]
+        }
+    }
+
+    requestDataMap[job](args['body'])
+
+    request(args, (err, response, body) => {
+        if (err) {
+            callback(err);
+        } else {
+            test.respCode = response.statusCode;
+            test.respBody = body;
+            callback();
+        }
+    });
+});
+
+Then('a job id is returned', function() {
+    let jobUuid = this.respBody['data']['uuid']
+    jobId = jobUuid
+    if (!jobUuid){
+        return 'job uuid not found!'
+    }
+})
+
+Then('the database has the appropriate indexes applied', {timeout: 60 * 1000}, function (callback) {
+    // Write code here that turns the phrase above into concrete actions
+    let test = this
+    let verify = function (job, callback) {
+        assert.equal(job['status'], 'Successful')
+        // TODO: Actually verify the job data
+        callback()
+    }
+
+    let jobUuid = test.respBody['data']['uuid']
+    this.waitForJobToComplete(jobUuid, verify, callback)
+
+});
+
+
+Then('the database has the appropriate map data', {timeout: 60 * 1000}, function (callback) {
+    // Write code here that turns the phrase above into concrete actions
+    let test = this
+    let verify = function (job, callback) {
+        assert.equal(job['status'], 'Successful')
+
+        MongoClient.connect(test.mongoUrl, function(err, db) {
+            try{
+                if (err) callback(err)
+                let dbo = db.db(test.appDb)
+                let dbc = dbo.collection('regions')
+                let query = { }
+
+                dbc.find(query).toArray(function(err, result){
+                    if (err) throw err;
+                    assert.equal(result.length, 10)
+
+                    let item = result[0];
+                    assert.equal(item.constellationIds.length, 5)
+                })
+                callback()
+            }
+            catch(err){
+                callback(err);
+            }
+            finally{
+                db.close()
+            }
+        });
+
+        callback()
+    }
+
+    let jobUuid = test.respBody['data']['uuid']
+    this.waitForJobToComplete(jobUuid, verify, callback)
+
+});
+
+Then('the database has the appropriate market data', {timeout: 60 * 1000}, function (callback) {
+    // Write code here that turns the phrase above into concrete actions
+    let test = this
+    let verify = function (job, callback) {
+        assert.equal(job['status'], 'Successful')
+
+        MongoClient.connect(test.mongoUrl, function(err, db) {
+            try{
+                if (err) callback(err)
+                let dbo = db.db(test.appDb)
+                let dbc = dbo.collection('marketOrders')
+                let query = { }
+
+                let count = dbc.count(query)
+                assert.equal(count, 2200)
+                callback()
+            }
+            catch(err){
+                callback(err);
+            }
+            finally{
+                db.close()
+            }
+        });
+
+        callback()
+    }
+
+    let jobUuid = test.respBody['data']['uuid']
+    this.waitForJobToComplete(jobUuid, verify, callback)
+
+});
+*/

--- a/tests/behavior/features/token.feature
+++ b/tests/behavior/features/token.feature
@@ -1,0 +1,22 @@
+Feature: Tokens
+
+  Verify that tokens operate as expected in the system
+
+  Scenario: API delete token removes token from system
+    Given I already have an auth token expiring in 10 seconds
+    When I log out of the system
+    Then the response code is 204
+    And a session no longer exists in the system for my token
+
+  Scenario: API Token refresh updates the system 
+    Given I already have an auth token expiring in 10 seconds
+    When I refresh the token with the system
+    Then the response code is 204
+    And the session for my token has an updated exipration timestamp
+
+  # I'm not sure we can test this since the mongo cleanup runs similarly to dotnet GC.
+  @ignore
+  Scenario: Tokens expire from the system appropriately
+    Given I already have an auth token expiring in -60 seconds
+    And wait for 1 seconds
+    Then a session no longer exists in the system for my token

--- a/tests/behavior/package.json
+++ b/tests/behavior/package.json
@@ -15,5 +15,9 @@
   },
   "dependencies": {
     "node-fetch": "^2.1.2"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/MadDonkeySoftware/corp-hq"
   }
 }


### PR DESCRIPTION
### Story
https://maddonkeysoftware.myjetbrains.com/youtrack/issue/CHQ-96

### Summary
* Added `TokenController` to handle user token specific operations
  * Current the `DELETE` option is used during log out
  * The `PUT` option was put in place to allow users to prevent a timeout on their session. 
* Stubbed `constants` section for the Vue events
* Added global event mechanism
* Adds ability for feature files to be ignored during runs of of the behavioral tests


### Testing

#### Log out code
* Start UI, API and mongo db.  
* Log in through the UI
  * Verify the nav bar is updated to remove the login/register buttons and now displays a logout button
* Verify mongo has a record in the `sessions` collection for your user
  * `db.sessions.find()`
* (Optional) Make a call to the session refresh endpoint then verify that the session expire timestamp is updated
  * `curl -X PUT  http://localhost:5000/api/v1/token/<your_token> -H 'Content-Type: application/json'
  * `db.sessions.find()`
* Click the logout button in the UI and verify the session has been deleted from the store
  * `db.sessions.find()`

#### Behave test ignore
* Add `@ignore` to any `Feature` or `Scenario`
* Run `./behave-ci-cd.sh` and verify it still passes but with less tests being run