### PR TITLE
CHQ-97 UI now runs in docker container using node rather than a simple HTTP server

### DIFF
--- a/Makefile.template
+++ b/Makefile.template
@@ -12,9 +12,6 @@ build-runner:  ## Builds the API displaying any analytics violations.
 build-runner-tests:  ## Builds the API tests.
 	dotnet build --no-incremental ./tests/unit/runnertest
 
-build-ui:  ## Builds the vue web site to deployable assets
-	npm run --prefix ./app/ui build
-
 docker-build-api: publish-api  ## Runs the docker build for the corp-hq api project
 	docker build --no-cache -t corp-hq-api ./app/api
 
@@ -23,7 +20,7 @@ docker-build-images: docker-build-api docker-build-runner docker-build-ui  ## Ru
 docker-build-runner: publish-runner  ## Runs the docker build for the corp-hq api project
 	docker build --no-cache -t corp-hq-runner ./app/runner
 
-docker-build-ui: build-ui  ## Runs the docker build for the corp-hq ui project
+docker-build-ui:  ## Runs the docker build for the corp-hq ui project
 	docker build --no-cache -t corp-hq-ui ./app/ui
 
 help:  ## Prints this help message.

--- a/app/api/Controllers/V1/JobController.cs
+++ b/app/api/Controllers/V1/JobController.cs
@@ -153,7 +153,7 @@ namespace Api.Controllers.V1
                     body: newJobUuid.ToByteArray());
             }
 
-            // TODO: Make base URL configurable.
+            // TODO: Make base URL configurable. -- CORPHQ_API_URL
             var baseUrl = new Uri("http://127.0.0.1:5000/api/v1/job/");
             var jobUrl = new Uri(baseUrl, newJobUuid.ToString());
             return this.Created(jobUrl, new ApiResponse<JobCreated> { Result = new JobCreated { Uuid = newJobUuid } });

--- a/app/api/Dockerfile
+++ b/app/api/Dockerfile
@@ -1,4 +1,4 @@
 FROM microsoft/aspnetcore
 WORKDIR /app
 COPY ./bin/Release/netcoreapp2.0/publish .
-ENTRYPOINT ["dotnet", "api.dll"]]
+ENTRYPOINT ["dotnet", "api.dll"]

--- a/app/ui/.dockerignore
+++ b/app/ui/.dockerignore
@@ -1,0 +1,3 @@
+node_modules
+.idea
+dist

--- a/app/ui/Dockerfile
+++ b/app/ui/Dockerfile
@@ -1,6 +1,13 @@
-FROM nginx:1.13.9-alpine
+FROM node:9
 LABEL Author="MadDonkeySoftware"
 LABEL WebSite="http://github.com/MadDonkeySoftware/corp-hq"
 
-# Install compiled app
-COPY ./dist /usr/share/nginx/html
+EXPOSE 8080
+
+WORKDIR /app
+
+# Copy over the files we need for build / run
+COPY . ./
+
+RUN ["npm", "install"]
+ENTRYPOINT ["npm", "run", "prod"]

--- a/app/ui/package.json
+++ b/app/ui/package.json
@@ -5,7 +5,8 @@
   "author": "Frito <fritogotlayed@gmail.com>",
   "private": true,
   "scripts": {
-    "dev": "webpack-dev-server --inline --progress --config build/webpack.dev.conf.js",
+    "dev": "webpack-dev-server --inline --host 0.0.0.0 --progress --config build/webpack.dev.conf.js",
+    "prod": "webpack-dev-server --host 0.0.0.0 --config build/webpack.prod.conf.js",
     "start": "npm run dev",
     "unit": "jest --config test/unit/jest.conf.js --coverage",
     "e2e": "node test/e2e/runner.js",

--- a/app/ui/src/pages/LogIn.vue
+++ b/app/ui/src/pages/LogIn.vue
@@ -49,6 +49,7 @@
 <script>
 import axios from 'axios'
 import constants from '@/constants'
+import utils from '@/utils'
 
 export default {
   name: 'Register',
@@ -69,7 +70,7 @@ export default {
           username: this.username,
           password: this.password
         }
-        axios.post('http://127.0.0.1:5000/api/v1/authentication', data)
+        axios.post(utils.buildApiUrl('/api/v1/authentication'), data)
           .then(response => {
             Event.fire(constants.authTokenUpdated, response.data['token'])
             this.$router.push({name: 'Dashboard', params: { userId: 123 }})

--- a/app/ui/src/pages/Register.vue
+++ b/app/ui/src/pages/Register.vue
@@ -78,6 +78,7 @@
 
 <script>
 import axios from 'axios'
+import utils from '@/utils'
 
 export default {
   name: 'Register',
@@ -104,7 +105,7 @@ export default {
           email: this.email,
           agreeWithTermsAndConditions: this.agreeWithTermsAndConditions
         }
-        axios.post('http://127.0.0.1:5000/api/v1/registration', data)
+        axios.post(utils.buildApiUrl('/api/v1/registration'), data)
           .then(response => {
             this.errors.push('Success!')
           })

--- a/app/ui/src/utils.js
+++ b/app/ui/src/utils.js
@@ -1,0 +1,19 @@
+export default {
+  getEnvironmentVar: function (varname, defaultvalue) {
+    var result = process.env[varname]
+    if (result !== undefined) {
+      // console.debug('ENV VAR used. ' + varname + ' ' + result)
+      return result
+    } else {
+      // console.debug('DEFAULT used. ' + varname + ' ' + defaultvalue)
+      return defaultvalue
+    }
+  },
+  buildApiUrl: function (part) {
+    let url = this.getEnvironmentVar('CORPHQ_API_URL', 'http://127.0.0.1:5000')
+    if (!part.startsWith('/')) {
+      url += '/'
+    }
+    return url + part
+  }
+}

--- a/behave-ci-cd.sh
+++ b/behave-ci-cd.sh
@@ -17,8 +17,6 @@ echo "Build the applications before we create docker images for them."
 echo "-----------"
 dotnet publish --configuration Release ./app/api
 dotnet publish --configuration Release ./app/runner
-npm install --prefix ./app/ui
-npm run --prefix ./app/ui build
 
 echo "-----------"
 echo "Build the images we will eventually test."


### PR DESCRIPTION
### Story
https://maddonkeysoftware.myjetbrains.com/youtrack/issue/CHQ-97

### Summary
* Updated the Vue.JS project to use node for it's web server rather than compiling the app to html/js and serving it via a simple HTTP server
  * The reasoning behind this is to not incur builds when switching the docker image between environments.
* Made the corp-hq api url configurable to the UI via the `CORPHQ_API_URL` environment variable. 

### Testing

#### Docker Image Change
* Use the make file to rebuild the docker image: `make docker-build-ui`
  * You may see a bunch of warnings. I plan to attempt cleaning these up under another task.
* Run the new UI container via the docker compose: `docker-compose up -d ui api`
  * Poke around the app as you normally would

#### Environment variable API url
* Run the app as normal with the make target or via `npm run dev`
* Verify you can still log into the application and/or can still register users.
* Stop the application and repeat the above steps with the `CORPHQ_API_URL` set to something other than "http://127.0.0.1:5000`