### PR TITLE
CHQ-101 Register then login workflow fixed.

### DIFF
--- a/app/ui/src/i18n/en.js
+++ b/app/ui/src/i18n/en.js
@@ -7,6 +7,7 @@ export default {
   'password': 'Password',
   'pleaseCorrectErrors': 'Please correct the following error(s):',
   'register': 'Register',
+  'registrationSuccessful': 'Registration successful. Please log in.',
   'reviewTermsAndConditions': 'Review them here.',
   'submit': 'Submit',
   'username': 'Username'

--- a/app/ui/src/pages/LogIn.vue
+++ b/app/ui/src/pages/LogIn.vue
@@ -2,7 +2,17 @@
   <section class="section">
     <div class="columns">
       <div class="column is-one-fifth"></div>
-        <div class="column is-danger" v-if="errors.length">
+        <div class="column" v-if="messages.length">
+          <ul>
+            <li v-for="message in messages" v-bind:key="message">{{ message }}</li>
+          </ul>
+        </div>
+      <div class="column is-one-fifth"></div>
+    </div>
+
+    <div class="columns">
+      <div class="column is-one-fifth"></div>
+        <div class="column" v-if="errors.length">
           <b>{{$t('pleaseCorrectErrors')}}</b>
           <ul>
             <li v-for="error in errors" v-bind:key="error">{{ error }}</li>
@@ -57,7 +67,8 @@ export default {
       submittingLogin: false,
       errors: [],
       username: '',
-      password: ''
+      password: '',
+      messages: []
     }
   },
   methods: {
@@ -91,6 +102,13 @@ export default {
 
       return this.errors.length === 0
     }
+  },
+  mounted () {
+    var parent = this
+    this.$store.state.messages.forEach(function (item, index) {
+      parent.messages.push(item)
+    })
+    this.$store.commit('clearMessages')
   }
 }
 </script>

--- a/app/ui/src/pages/Register.vue
+++ b/app/ui/src/pages/Register.vue
@@ -107,7 +107,8 @@ export default {
         }
         axios.post(utils.buildApiUrl('/api/v1/registration'), data)
           .then(response => {
-            this.errors.push('Success!')
+            this.$store.commit('addMessage', {message: this.$t('registrationSuccessful')})
+            this.$router.push({name: 'LogIn'})
           })
           .catch(e => {
             e.response.data['messages'].forEach(message => {

--- a/app/ui/src/store/index.js
+++ b/app/ui/src/store/index.js
@@ -4,12 +4,19 @@ import Vuex from 'vuex'
 Vue.use(Vuex)
 
 const state = {
-  apiKey: null
+  apiKey: null,
+  messages: []
 }
 
 const mutations = {
   updateKey (state, payload) {
     state.apiKey = payload.apiKey
+  },
+  clearMessages (state) {
+    state.messages = []
+  },
+  addMessage (state, payload) {
+    state.messages.push(payload.message)
   }
 }
 

--- a/mongo-scripts/local-seed-data.js
+++ b/mongo-scripts/local-seed-data.js
@@ -8,6 +8,16 @@ var rabbitSettings = {
     recordTtl: 5,
     recordHeartbeat: 1
 };
+var eveDataUri = "https://esi.tech.ccp.is/latest";
 
-db.settings.replaceOne({ key: "rabbitConnection" }, { key: "rabbitConnection", value: rabbitSettings}, {upsert: true});
-db.settings.replaceOne({ key: "eveDataUri" }, { key: "eveDataUri", value: "https://esi.tech.ccp.is/latest"}, {upsert: true});
+var updateSetting = function (key, value) {
+    try {
+        db.settings.replaceOne({ key: key }, { key: key, value: value }, { upsert: true })
+    } catch (error) {
+        db.settings.remove({ key: key })
+        db.settings.insert({ key: key , value: value })
+    }
+}
+
+updateSetting("rabbitConnection", rabbitSettings)
+updateSetting("eveDataUri", eveDataUri)


### PR DESCRIPTION
### Story
https://maddonkeysoftware.myjetbrains.com/youtrack/issue/CHQ-101

### Summary
* Fixed seed data to allow run against mongo version that doesn't support `replaceOne`
* Now after successful registration user will be redirected to the log in page with a message indicating their registration was successful.

### Testing
* Start UI and API projects
* Register a new user.
* Verify screen redirected to log in page and message indicating successful registration occurred.
