### PR TITLE
CHQ-104 UI can now be run in docker behind nginx to simulate a non-local environment.

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ## Useful Links
 * [Discord](https://discord.gg/FvTw9pF) - General discussion and place to possibly talk to the developers
-* [YouTrack](https://maddonkeysoftware.myjetbrains.com/youtrack/agiles/93-1/94-16) - Our bug / task tracking location
+* [YouTrack](https://maddonkeysoftware.myjetbrains.com/youtrack/agiles) - Our bug / task tracking location
 
 ## Contributing
 Please see the `docs` section of the source base. `local_dev.md` and `local_security.md` may be the most useful.

--- a/app/api/Program.cs
+++ b/app/api/Program.cs
@@ -6,6 +6,7 @@ namespace Api
     using System.Collections.Generic;
     using System.IO;
     using System.Linq;
+    using System.Net;
     using System.Threading.Tasks;
     using Microsoft.AspNetCore;
     using Microsoft.AspNetCore.Hosting;
@@ -33,6 +34,10 @@ namespace Api
         /// <returns>An IWebHost</returns>
         public static IWebHost BuildWebHost(string[] args) =>
             WebHost.CreateDefaultBuilder(args)
+                .UseKestrel(options =>
+                {
+                    options.Listen(IPAddress.Any, 5000);
+                })
                 .UseStartup<Startup>()
                 .Build();
     }

--- a/app/ui/package.json
+++ b/app/ui/package.json
@@ -6,6 +6,7 @@
   "private": true,
   "scripts": {
     "dev": "webpack-dev-server --inline --host 0.0.0.0 --progress --config build/webpack.dev.conf.js",
+    "dev-docker": "webpack-dev-server --inline --disable-host-check --host 0.0.0.0 --port 80 --config build/webpack.dev.conf.js",
     "prod": "webpack-dev-server --host 0.0.0.0 --config build/webpack.prod.conf.js",
     "start": "npm run dev",
     "unit": "jest --config test/unit/jest.conf.js --coverage",

--- a/app/ui/src/classes/form.js
+++ b/app/ui/src/classes/form.js
@@ -19,9 +19,6 @@ export default class Form {
       data[property] = this[property]
     }
 
-    delete data.errors
-    delete data.originalData
-
     return data
   }
 

--- a/app/ui/src/utils.js
+++ b/app/ui/src/utils.js
@@ -10,7 +10,7 @@ export default {
     }
   },
   buildApiUrl: function (part) {
-    let url = this.getEnvironmentVar('CORPHQ_API_URL', 'http://127.0.0.1:5000')
+    let url = ''
     if (!part.startsWith('/')) {
       url += '/'
     }

--- a/behave-ci-cd.sh
+++ b/behave-ci-cd.sh
@@ -44,7 +44,7 @@ echo "-----------"
 echo "Sleeping $CORPHQ_BEHAVE_SLEEP seconds then starting the tests."
 echo "-----------"
 sleep $CORPHQ_BEHAVE_SLEEP
-docker run -it -v $(pwd)/tests/behavior:/home/node/app -w="/home/node/app" -e CORPHQ_BEHAVE_STEP_TIMEOUT=$CORPHQ_BEHAVE_STEP_TIMEOUT --network="test-network" --name test-node node:8 bash -c "npm install; API_URL=http://test-api MONGO_URL=mongodb://test-mongodb:27017/auth npm run cucumber -- --tags 'not @ignore'"
+docker run -it -v $(pwd)/tests/behavior:/home/node/app -w="/home/node/app" -e CORPHQ_BEHAVE_STEP_TIMEOUT=$CORPHQ_BEHAVE_STEP_TIMEOUT --network="test-network" --name test-node node:8 bash -c "npm install; API_URL=http://test-api:5000 MONGO_URL=mongodb://test-mongodb:27017/auth npm run cucumber -- --tags 'not @ignore'"
 EXIT_CODE="$(docker inspect --format='{{.State.ExitCode}}' test-node)"
 docker rm test-node -v
 

--- a/docs/local_dev.md
+++ b/docs/local_dev.md
@@ -1,11 +1,16 @@
 # Local Development Guide
 - [Local Development Guide](#local-development-guide)
+  - [Quick Start](#quick-start)
   - [General Notes](#general-notes)
   - [Requirements](#requirements)
   - [Install Dependencies](#install-dependencies)
   - [Running the applications and dependencies](#running-the-applications-and-dependencies)
   - [Getting Help](#getting-help)
     - [Core developers](#core-developers)
+
+## Quick Start
+This quick start assumes you have docker and docker-compose installed already.
+* Run the `quick-start.sh` script.
 
 ## General Notes
 * `<root>` will signify the root directory of this solution. This is the directory with "LICENSE" and "app" in it.
@@ -55,7 +60,6 @@ One excellent way of getting help getting your environment set up is to ask a qu
 ### Core developers
 As cores join and leave the project we will try to keep this list as up to date as possible.
 
-| Developer (GitHub user) | Environment   |
-| ----------------------- | ------------- |
-| fritogotlayed           | Mac OS        |
-| naitp                   | Linux         |
+| Developer (GitHub user) | Environment    |
+| ----------------------- | -------------- |
+| fritogotlayed           | Mac OS & Linux |

--- a/mongo-scripts/local-seed-data.js
+++ b/mongo-scripts/local-seed-data.js
@@ -1,7 +1,7 @@
 var rabbitSettings = {
     hosts: [
-        // {address: "rabbit"},
-        {address: "localhost"}
+        {address: "rabbit"},
+        // {address: "localhost"}
     ],
     username: "rabbitmq",
     password: "rabbitmq",

--- a/mongo-scripts/test-seed-data.js
+++ b/mongo-scripts/test-seed-data.js
@@ -7,6 +7,16 @@ var rabbitSettings = {
     recordTtl: 5,
     recordHeartbeat: 1
 };
+var eveDataUri = "http://test-eve-api:3000";
 
-db.settings.replaceOne({ key: "rabbitConnection" }, { key: "rabbitConnection", value: rabbitSettings}, {upsert: true});
-db.settings.replaceOne({ key: "eveDataUri" }, { key: "eveDataUri", value: "http://test-eve-api:3000"}, {upsert: true});
+var updateSetting = function (key, value) {
+    try {
+        db.settings.replaceOne({ key: key }, { key: key, value: value }, { upsert: true })
+    } catch (error) {
+        db.settings.remove({ key: key })
+        db.settings.insert({ key: key , value: value })
+    }
+}
+
+updateSetting("rabbitConnection", rabbitSettings)
+updateSetting("eveDataUri", eveDataUri)

--- a/nginx-files/nginx.conf
+++ b/nginx-files/nginx.conf
@@ -1,0 +1,44 @@
+worker_processes 1;
+
+events { worker_connections 1024; }
+
+http {
+
+    sendfile on;
+    resolver    127.0.0.11 valid=5s;
+
+    upstream docker-ui {
+        server  corp-hq-ui:80;
+    }
+
+    upstream docker-api {
+        server  corp-hq-api:5000;
+    }
+
+    server {
+        # We have to do a variable for the endpoints since the docker DNS may have the incorrect IP when nginx attempts to cache the resolution.
+        listen 80;
+        set $uidn   "docker-ui";
+        set $apidn  "docker-api";
+
+
+        location / {
+            proxy_pass         http://$uidn;
+            proxy_redirect     off;
+            proxy_set_header   Host $host;
+            proxy_set_header   X-Real-IP $remote_addr;
+            proxy_set_header   X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header   X-Forwarded-Host $server_name;
+        }
+
+        location /api {
+            proxy_pass         http://$apidn;
+            proxy_redirect     off;
+            proxy_set_header   Host $host;
+            proxy_set_header   X-Real-IP $remote_addr;
+            proxy_set_header   X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header   X-Forwarded-Host $server_name;
+        }
+    }
+
+}

--- a/quick-start.sh
+++ b/quick-start.sh
@@ -1,0 +1,40 @@
+#!/bin/bash
+
+echo "-----------"
+echo "Welcome to the Corp-HQ quick start script. We will attempt to bring you"
+echo "from scratch to a fully working environment."
+echo "-----------"
+echo ""
+
+# Just make sure the containers are being build fresh
+docker-compose -f quickstart-compose.yml down -v 1>/dev/null 2>/dev/null
+
+echo "-----------"
+echo "First we start up the dependencies."
+echo "-----------"
+docker-compose -f quickstart-compose.yml up -d mongodb eve-api rabbitmq
+
+echo "-----------"
+echo "Next we seed the database with some settings"
+echo "-----------"
+sleep 2
+docker exec -it mongodb mongo 127.0.0.1:27017/corp-hq /var/scripts/local-seed-data.js
+
+echo "-----------"
+echo "Now we can start the proxy, API and UI components. The proxy listens on"
+echo "port 80 so you should be able to browse to http://localhost for the site."
+echo "-----------"
+docker-compose -f quickstart-compose.yml up -d proxy ui api
+
+echo "-----------"
+echo "Next we sleep about 30 seconds before starting the background runner."
+echo "This is to give the API enough time to finish compiling before we start"
+echo "compiling the runner. This is due to both containers sharing resources."
+echo "-----------"
+sleep 30
+docker-compose -f quickstart-compose.yml up -d runner
+
+echo "-----------"
+echo "Yay! You're done. When you've finished simply run the below command."
+echo "docker-compose -f quickstart-compose.yml down -v"
+echo "-----------"

--- a/quickstart-compose.yml
+++ b/quickstart-compose.yml
@@ -30,7 +30,7 @@ services:
         links:
             - "mongodb:mongo"
             - "rabbitmq:rabbit"
-        command: bash -c "sleep 10 && dotnet build --no-incremental ./app/runner && dotnet run -p ./app/runner"
+        command: bash -c "sleep 0 && dotnet build --no-incremental ./app/runner && dotnet run -p ./app/runner"
     mongodb:
         container_name: "mongodb"
         image: mongo:3.6.3
@@ -39,6 +39,7 @@ services:
             - MONGO_LOG_DIR=/dev/null
         volumes:
             - ./mongo-data/db:/data/db
+            - ./mongo-scripts:/var/scripts
         ports:
             - 27017:27017
         command: mongod --smallfiles --logpath=/dev/null  # -auth  # --quiet
@@ -67,8 +68,8 @@ services:
             - 5672:5672
         labels:
             NAME: "rabbitmq1"
-    nginx:
-        container_name: "nginx"
+    proxy:
+        container_name: "proxy"
         image: nginx:alpine
         volumes:
             - ./nginx-files/nginx.conf:/etc/nginx/nginx.conf


### PR DESCRIPTION
### Story
https://maddonkeysoftware.myjetbrains.com/youtrack/issue/CHQ-104

### Summary
* Updated API to listen on 0.0.0.0 rather than localhost.
* Updated UI with new run endpoint to listen on port 80
  * This is due to webpack and it's websocket stuff sending javascript to the browser that has the port explicitly stated in it
* Adjusted documentation as needed
* Built quick-start solution to allow someone to go from "nothing" to the app running locally with minimal interaction.

### Testing
* Run `quick-start.sh`
* Poke around in the application. Register a user. Log in.
